### PR TITLE
Fix return type from face generator

### DIFF
--- a/utils/generate_face_shapes.py
+++ b/utils/generate_face_shapes.py
@@ -14,7 +14,8 @@ def generate_facial_data_from_bytes(audio_bytes, model, device, config):
     audio_features, y = extract_audio_features(audio_bytes, from_bytes=True)
     
     if audio_features is None or y is None:
-        return [], np.array([])
+        # Return an empty array to maintain a consistent return type
+        return np.array([])
   
     final_decoded_outputs = process_audio_features(audio_features, model, device, config)
 


### PR DESCRIPTION
## Summary
- handle invalid audio data uniformly
- always return numpy array from face shape generator

## Testing
- `python -m py_compile neurosync_local_api.py utils/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68402158b6cc83309315a2dd5454c616